### PR TITLE
Drop Python 3.8 Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,5 @@ jobs:
   main-linux:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.6.0
     with:
-      env: '["py38", "py39", "py310", "py311", "py312", "py313"]'
+      env: '["py39", "py310", "py311", "py312", "py313"]'
       os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   main-windows:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.6.0
     with:
-      env: '["py38"]'
+      env: '["py39"]'
       os: windows-latest
   main-linux:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.6.0

--- a/clean_dotenv/_main.py
+++ b/clean_dotenv/_main.py
@@ -1,10 +1,10 @@
 import os
 import argparse
-from typing import Iterator, List
+from collections.abc import Iterator
 import clean_dotenv._parser as DotEnvParser
 
 
-def _clean_env(path_to_env: str, values_to_keep: List[str] = []):
+def _clean_env(path_to_env: str, values_to_keep: list[str] = []):
     # Open the .env file and remove the sensitive data
     # We rely on python-dotenv to parse the file, since we do not want to write our own parser
     dotenv_elements = DotEnvParser.parse_stream(open(path_to_env))
@@ -44,7 +44,7 @@ def _find_dotenv_files(path_to_root: str) -> Iterator[str]:
             yield entry.path
 
 
-def _main(path_to_root: str, values_to_keep: List[str] = []):
+def _main(path_to_root: str, values_to_keep: list[str] = []):
     # Find possible .env files
     for dotenv_file in _find_dotenv_files(path_to_root):
         # Clean dotenv file

--- a/clean_dotenv/_parser.py
+++ b/clean_dotenv/_parser.py
@@ -33,14 +33,11 @@ import codecs
 import re
 from typing import (
     IO,
-    Iterator,
-    Match,
     NamedTuple,
-    Optional,  # noqa:F401
-    Pattern,
-    Sequence,
-    Tuple,
+    Optional,
 )
+from collections.abc import Iterator, Sequence
+from re import Match, Pattern
 
 
 def make_regex(string: str, extra_flags: int = 0) -> Pattern[str]:
@@ -162,7 +159,7 @@ def parse_unquoted_value(reader: Reader) -> str:
     return re.sub(r"\s+#.*", "", part).rstrip()
 
 
-def parse_value(reader: Reader) -> Tuple[str, str]:
+def parse_value(reader: Reader) -> tuple[str, str]:
     char = reader.peek(1)
     if char == "'":
         (value,) = reader.read_regex(_single_quoted_value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Python 3.8 drops support in October 2024.

This PR:

- Removes Python 3.8 support
- Updates some code to use Python syntax (i.e. typing) which was not easily possible with Python 3.8