### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
   main-windows:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.8.1
     with:
-      env: '["py39"]'
+      env: '["py310"]'
       os: windows-latest
   main-linux:
     uses: asottile/workflows/.github/workflows/tox.yml@v1.8.1
     with:
-      env: '["py39", "py310", "py311", "py312", "py313", "py314"]'
+      env: '["py310", "py311", "py312", "py313", "py314"]'
       os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v3.16.0
     hooks:
       - id: reorder-python-imports
-        args: [--py39-plus]
+        args: [--py310-plus]
   - repo: https://github.com/asottile/add-trailing-comma
     rev: v4.0.0
     hooks:
@@ -19,4 +19,4 @@ repos:
     rev: v3.21.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]

--- a/clean_dotenv/_parser.py
+++ b/clean_dotenv/_parser.py
@@ -60,14 +60,14 @@ class Original(NamedTuple):
 
 
 class Binding(NamedTuple):
-    multiline_whitespace: Optional[str]
-    export: Optional[str]
-    key: Optional[str]
-    value: Optional[str]
-    separator: Optional[str]
+    multiline_whitespace: str | None
+    export: str | None
+    key: str | None
+    value: str | None
+    separator: str | None
     original: Original
-    comment: Optional[str]
-    end_of_line: Optional[str]
+    comment: str | None
+    end_of_line: str | None
     error: bool
 
 
@@ -136,7 +136,7 @@ def decode_escapes(regex: Pattern[str], string: str) -> str:
     return regex.sub(decode_match, string)
 
 
-def parse_key(reader: Reader) -> Optional[str]:
+def parse_key(reader: Reader) -> str | None:
     char = reader.peek(1)
     if char == '#':
         return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
- Python 3.9 reached EOL. As a result, we do not support it anymore.